### PR TITLE
Add the methods "remove" and "contains_key"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,29 @@ impl TypeMap {
         Self(HashMap::new())
     }
 
+    /// Returns `true` if the map contains a value for the specified key.
+    ///
+    /// ```rust
+    /// use typemap_rev::{TypeMap, TypeMapKey};
+    ///
+    /// struct Number;
+    ///
+    /// impl TypeMapKey for Number {
+    ///     type Value = i32;
+    /// }
+    ///
+    /// let mut map = TypeMap::new();
+    /// assert!(!map.contains_key::<Number>());
+    /// map.insert::<Number>(42);
+    /// assert!(map.contains_key::<Number>());
+    /// ```
+    pub fn contains_key<T>(&self) -> bool
+    where
+        T: TypeMapKey
+    {
+        self.0.contains_key(&TypeId::of::<T>())
+    }
+
     /// Inserts a new value based on its [`TypeMapKey`].
     /// If the value has been already inserted, it will be overwritten
     /// with the new value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ impl TypeMap {
         Self(HashMap::new())
     }
 
-    /// Returns `true` if the map contains a value for the specified key.
+    /// Returns `true` if the map contains a value for the specified [`TypeMapKey`].
     ///
     /// ```rust
     /// use typemap_rev::{TypeMap, TypeMapKey};
@@ -164,10 +164,8 @@ impl TypeMap {
             .and_then(|b| b.downcast_mut::<T::Value>())
     }
 
-    /// Removes a key from the map, returning the value at the key if the key was previously in the
-    /// map.
-    ///
-    /// Returns `None` if the key has not been in the map.
+    /// Removes a value from the map based on its [`TypeMapKey`], returning the value or `None` if
+    /// the key has not been in the map.
     ///
     /// ```rust
     /// use typemap_rev::{TypeMap, TypeMapKey};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ impl TypeMap {
     /// map.insert::<Number>(42);
     /// assert!(map.contains_key::<Number>());
     /// ```
+    #[inline]
     pub fn contains_key<T>(&self) -> bool
     where
         T: TypeMapKey
@@ -182,6 +183,7 @@ impl TypeMap {
     /// assert!(map.remove::<Text>().is_some());
     /// assert!(map.get::<Text>().is_none());
     /// ```
+    #[inline]
     pub fn remove<T>(&mut self) -> Option<T::Value>
     where
         T: TypeMapKey


### PR DESCRIPTION
Hey! The previous type map implementation used by serenity provided methods to [remove](https://docs.rs/typemap/0.3.3/typemap/struct.TypeMap.html#method.remove) a value from the map and [check](https://docs.rs/typemap/0.3.3/typemap/struct.TypeMap.html#method.contains) if a key is present in the map, in accordance with the standard library's map interface ([`remove`](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#method.remove), [`contains_key`](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#method.contains_key)).

This PR aims to re-introduce those methods in the current type map implementation, as they are useful for some situations.

The functionality provided here is not really new - you can implement `contains_key` in terms of `get` (`get::<T>().is_some()`), and you can remove entries through [`OccupiedEntry::remove`](https://docs.rs/typemap_rev/0.1.3/typemap_rev/struct.OccupiedEntry.html#method.remove), although a bit tedious. Apart from convenience however, the implementation in this PR does allow you to get the original (owned) value back from the map - which is nice for types which are not `Copy`able, or not even `Clone`able.

One could even think about changing the interface of `OccupiedEntry::remove` to also return the original value - just like the [original from HashMap](https://doc.rust-lang.org/stable/std/collections/hash_map/struct.OccupiedEntry.html#method.remove) - but since that changes the existing API, I considered it out of scope for this PR and something that could be done separately.